### PR TITLE
Fix lightline's tabline and terminal middle section

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox8.vim
+++ b/autoload/lightline/colorscheme/gruvbox8.vim
@@ -28,7 +28,7 @@ let s:p.insert.middle = [ [ s:fg4, s:bg2 ] ]
 
 let s:p.terminal.left   = [ [ s:bg0, s:green, 'bold' ], [ s:fg1, s:bg2 ] ]
 let s:p.terminal.right  = [ [ s:bg0, s:green ], [ s:fg1, s:bg2 ] ]
-let s:p.terminal.middle = [ [ s:fg4, s:bg2 ] ]
+let s:p.terminal.middle = [ [ s:fg4, s:bg1 ] ]
 
 let s:p.replace.left   = [ [ s:bg0, s:aqua, 'bold' ], [ s:fg1, s:bg2 ] ]
 let s:p.replace.right  = [ [ s:bg0, s:aqua ], [ s:fg1, s:bg2 ] ]
@@ -40,7 +40,7 @@ let s:p.visual.middle = [ [ s:fg4, s:bg1 ] ]
 
 let s:p.tabline.left   = [ [ s:fg4, s:bg2 ] ]
 let s:p.tabline.right  = [ [ s:bg0, s:orange ] ]
-let s:p.tabline.middle = [ [ s:bg0, s:bg0 ] ]
+let s:p.tabline.middle = [ [ s:bg0, s:bg4 ] ]
 let s:p.tabline.tabsel = [ [ s:bg0, s:fg4 ] ]
 
 let s:p.normal.error   = [ [ s:bg0, s:orange ] ]


### PR DESCRIPTION
Tabline middle section was black instead of gray.
Terminal middle section was the same color as the left/right sections.

This PR fixes those issues.
It follows the same colors as ```gruvbox-community/gruvbox```.